### PR TITLE
fix lint

### DIFF
--- a/docs/11-Vehicle-Specific/Mazda-MX5-Miata/11-Miata-MX5-Quick-Start.md
+++ b/docs/11-Vehicle-Specific/Mazda-MX5-Miata/11-Miata-MX5-Quick-Start.md
@@ -155,6 +155,7 @@ There are three ways of tuning the VE table. The first way is to drive the car a
 Next, click the tab labelled _Tune Analyze Live! - Tune For You_ to bring up the autotuner. Click to the _Advanced Settings_ tab and configure it as shown in the image below. These configuration settings are deliberately quite loose so that TS can quickly tune the general shape of the VE table. On the left side of the _VE Table Control Panel_, you also need to check the box marked _Update Controller_ which ensures that the VE table is updated on the ECU as the autotune corrects itself.
 
 ![image](Miata-MX5-Quick-Start-Images/autotune2.jpg)
+
 | **Setting** | **Value** |
 |------------------------------|----- |
 | Cell Change Resistance       | Easy |
@@ -223,6 +224,7 @@ Now that the autotuner is set up, start the car and click _Start Auto Tune_ on t
 - You can Lock cells by highlighting them and locking them. Such as Idle or Coasting sections.
 
 For Example 
+
 | **Setting** | **Value** |
 |------------------------------|----- |
 | Cell Change Resistance       | Hard / Very Hard |

--- a/docs/11-Vehicle-Specific/Mazda-MX5-Miata/11-Miata-MX5-Quick-Start.md
+++ b/docs/11-Vehicle-Specific/Mazda-MX5-Miata/11-Miata-MX5-Quick-Start.md
@@ -167,7 +167,7 @@ Next, click the tab labelled _Tune Analyze Live! - Tune For You_ to bring up the
 | vBatt                        | 12   |
 | Minimum TPS                  | 3    |
 
-Now that the autotuner is set up, start the car and click _Start Auto Tune_ on the autotuner. Let the car idle in park whilst it gets up to the minimum temperature. While this happens, you can change the idle cells in the VE table to get them to a lambda of 1. Follow the Cursor on the VE table while idling and adjust the values your car is at while monitoring the lambda value. Once the car has warmed up its time to auto tune. After you are sufficiently happy, click Stop Auto Tune, turn the engine off and click Save on ECU. Below is a auto tune guideline
+Now that the autotuner is set up, start the car and click _Start Auto Tune_ on the autotuner. Let the car idle in park whilst it gets up to the minimum temperature. While this happens, you can change the idle cells in the VE table to get them to a lambda of 1. Follow the Cursor on the VE table while idling and adjust the values your car is at while monitoring the lambda value. Once the car has warmed up its time to autotune. After you are sufficiently happy, click Stop Auto Tune, turn the engine off and click Save on ECU. Below is an autotune guideline.
 
 ## Safety First
 
@@ -220,10 +220,10 @@ Now that the autotuner is set up, start the car and click _Start Auto Tune_ on t
 ### 1. Repeat and Refine
 
 - Drive again, following the same driving guidelines to gather more data and further refine the settings in autotune to achieve a better VE table.
-- Multiple iterations with multiple settings may be necessary to achieve an optimal VE table. 
+- Multiple iterations with multiple settings may be necessary to achieve an optimal VE table.
 - You can Lock cells by highlighting them and locking them. Such as Idle or Coasting sections.
 
-For Example 
+For Example:
 
 | **Setting** | **Value** |
 |------------------------------|----- |


### PR DESCRIPTION
https://github.com/FOME-Tech/wiki/actions/runs/12704027248/job/35412740035#step:5:11

```
Run npm run lint:md

> wiki@0.0.0 lint:md
> npx -y markdownlint-cli docs

docs/11-Vehicle-Specific/Mazda-MX5-Miata/11-Miata-MX5-Quick-Start.md:158 MD058/blanks-around-tables Tables should be surrounded by blank lines [Context: "| **Setting** | **Value** |"]
docs/11-Vehicle-Specific/Mazda-MX5-Miata/11-Miata-MX5-Quick-Start.md:226 MD058/blanks-around-tables Tables should be surrounded by blank lines [Context: "| **Setting** | **Value** |"]
Error: Process completed with exit code 1.
```

----

For whatever reason, I don't receive these lint errors locally.

`npm --versions`
```js
{
  wiki: '0.0.0',
  npm: '9.2.0',
  node: '20.18.1',
  acorn: '8.8.1',
  ada: '2.9.2',
  ares: '1.34.2',
  base64: '0.5.2',
  brotli: '1.1.0',
  cjs_module_lexer: '1.2.3',
  cldr: '42.0',
  icu: '72.1',
  llhttp: '8.1.2',
  modules: '115',
  napi: '9',
  nghttp2: '1.64.0',
  openssl: '3.3.2',
  simdutf: '5.5.0',
  tz: '2022e',
  unicode: '15.0',
  uv: '1.48.0',
  uvwasi: '0.0.21',
  v8: '11.3.244.8-node.23',
  zlib: '1.3.1'
}
```

`npm run lint`
```
> wiki@0.0.0 lint
> npm run lint:biome && npm run lint:ts && npm run lint:links && npm run lint:md


> wiki@0.0.0 lint:biome
> biome check .

Checked 32 file(s) in 8ms

> wiki@0.0.0 lint:ts
> tsc


> wiki@0.0.0 lint:links
> node scripts/linkValidator.js 'docs/**/*.md?(x)'

Validating rules for URL links in: 154 files
✅ Ok

> wiki@0.0.0 lint:md
> npx -y markdownlint-cli docs
```

`npx markdownlint-cli --version`
```
0.36.0
```